### PR TITLE
environment:sql-size: Use Table for output

### DIFF
--- a/src/Command/Environment/EnvironmentSqlSizeCommand.php
+++ b/src/Command/Environment/EnvironmentSqlSizeCommand.php
@@ -7,7 +7,6 @@ use Platformsh\Cli\Helper\ShellHelper;
 use Platformsh\Cli\Util\RelationshipsUtil;
 use Platformsh\Cli\Util\Table;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Yaml\Yaml;
 
@@ -32,8 +31,6 @@ class EnvironmentSqlSizeCommand extends CommandBase {
 
         /** @var ShellHelper $shellHelper */
         $shellHelper = $this->getHelper('shell');
-        $bufferedOutput = new BufferedOutput();
-        $shellHelper->setOutput($bufferedOutput);
 
         // Get and parse app config.
         $args = ['ssh', $sshUrl, 'echo $' . self::$config->get('service.env_prefix') . 'APPLICATION'];


### PR DESCRIPTION
- Use Table for output instead of SymfonyStyle
- Remove BufferedOutput (mainly to see the command name with `-v`)
- Reformats code (PSR-2 / Symfony / my subjective preferences)